### PR TITLE
Hotfix - Alteração do nome da biblioteca

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "praqt/boletos-nosso-numero",
+    "name": "praqt/praqt-boletos-nosso-numero",
     "description": "Gera o Nosso Numero dos boletos",
     "type": "library",
     "authors": [


### PR DESCRIPTION
Inserção do nome praqt no nome, mantendo o padrão já utilizado.